### PR TITLE
Issue #12 exit code status not being kept. Wrapped the subprocess.cal…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tools/lintstack.head.py
 tools/pylint_exceptions
 .cache
 .env
+venv/*

--- a/rabbit/command.py
+++ b/rabbit/command.py
@@ -1,5 +1,6 @@
 import click
 import subprocess
+import sys
 
 class Command(object):
 	""" Command Class
@@ -76,4 +77,4 @@ class Command(object):
 		toCommand = self.data.get('to')
 		extraArgs = ' '.join(context.args)
 		runCommand = '{0} {1}'.format(toCommand, extraArgs)
-		subprocess.call(runCommand, shell=True)
+		sys.exit(subprocess.call(runCommand, shell=True))

--- a/rabbit/tests/test_command.py
+++ b/rabbit/tests/test_command.py
@@ -210,5 +210,25 @@ class TestCommand(unittest.TestCase):
 		context = MagicMock()
 		context.args = ['foo', 'bar']
 		expected = 'test foo bar'
-		result = command.run(context)
+		try:
+			result = command.run(context)
+		except SystemExit as e:
+			self.assertTrue(isinstance(e.code, MagicMock))
 		call_mock.assert_called_with(expected, shell=True)
+
+	"""
+	run
+	- it tests if the run command returns the correct exit codes
+	"""
+	def test_run_command_returns_correct_exit_codes(self):
+		command = Command({'to': 'ls &> /dev/null', 'hop': 'go'})
+		context = MagicMock()
+		try:
+			command.run(context)
+		except SystemExit as e:
+			self.assertEquals(e.code, 0)
+		context.args = ['foo', 'bar']
+		try:
+			command.run(context)
+		except SystemExit as e:
+			self.assertEquals(e.code, 1)

--- a/rabbit/tests/test_command.py
+++ b/rabbit/tests/test_command.py
@@ -231,4 +231,4 @@ class TestCommand(unittest.TestCase):
 		try:
 			command.run(context)
 		except SystemExit as e:
-			self.assertEquals(e.code, 1)
+			self.assertNotEquals(e.code, 0)


### PR DESCRIPTION
…l() in a sys.exit() to use the exit code of the command being ran in rabbit and the exit code for the callback. Also modified a test and wrote another one to prove this is working as expected.
